### PR TITLE
Fix for hungarian notation field name formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'realm-android'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         applicationId "dk.ilios.example.realmfieldnames"
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:24.2.0'
     apt project(':library')
 }

--- a/library/src/main/java/dk/ilios/realmfieldnames/FieldNameFormatter.java
+++ b/library/src/main/java/dk/ilios/realmfieldnames/FieldNameFormatter.java
@@ -38,7 +38,7 @@ public class FieldNameFormatter {
                 currentCodepoint = fieldName.codePointAt(offset);
 
                 if (previousCodepoint != null) {
-                    if (Character.isUpperCase(currentCodepoint) && !Character.isUpperCase(previousCodepoint) && previousCodepoint == 'm') {
+                    if (Character.isUpperCase(currentCodepoint) && !Character.isUpperCase(previousCodepoint) && previousCodepoint == 'm' && result.length() == 1) {
                         // Hungarian notation starting with: mX
                         result.delete(0, 1);
                         result.appendCodePoint(currentCodepoint);

--- a/library/src/test/java/dk/ilios/realmfieldnames/FieldNameFormatterTests.java
+++ b/library/src/test/java/dk/ilios/realmfieldnames/FieldNameFormatterTests.java
@@ -74,6 +74,15 @@ public class FieldNameFormatterTests {
         assertEquals("FOO", result);
     }
 
+    /**
+     * @see <a href="https://github.com/cmelchior/realmfieldnameshelper/issues/6">Some Field names are missing leading Character</a>
+     */
+    @Test
+    public void issue6() {
+        String result = formatter.format("itemQuantityDelta");
+        assertEquals("ITEM_QUANTITY_DELTA", result);
+    }
+
     @Test
     public void useUSLocaleForConversion() {
         // Right now we use the US locale to do the conversion.


### PR DESCRIPTION
This PR addresses issue #6 

The check for hungarian notation `Character.isUpperCase(currentCodepoint) && !Character.isUpperCase(previousCodepoint) && previousCodepoint == 'm'` doesn't consider the 'm' to be the fist letter. In the example of issue #6 `itemQuantityDelta` the 'm' with the following 'Q' has been detected as hungarian and the first letter 'i' was mistakenly removed.

What I changed:
- Updated Android-Gradle-Plugin, buildToolsVersion and appCompat-Library
- Added check for the current length of the field name when detecting hungarian notation
- Added a test case for this issue
